### PR TITLE
Fixed crit cash dispatching wrong particle effect.

### DIFF
--- a/addons/sourcemod/scripting/tank.sp
+++ b/addons/sourcemod/scripting/tank.sp
@@ -8546,6 +8546,12 @@ void CritCash_RemoveEffects()
 	}
 }
 
+public Action CritCash_OnSpawnPost(int entity)
+{
+	// After the 2015 Halloween update, currency packs will not spawn if there's no nav mesh. This allows Crit Cash to spawn on maps without a nav mesh!
+	SetEntProp(entity, Prop_Send, "m_bDistributed", true);
+}
+
 public Action Bomb_OnTouch(int iBomb, int iToucher)
 {
 	// Don't allow bomb pickup until the round has started and the bomb has been handed off to a giant
@@ -9338,8 +9344,8 @@ public void OnEntityCreated(int iEntity, const char[] classname)
 		}else{
 			// Hook currency touch to award crits to the red team
 			SDKHook(iEntity, SDKHook_Touch, CritCash_OnTouch);
-			// After the 2015 Halloween update, currency packs will not spawn if there's no nav mesh. This allows Crit Cash to spawn on maps without a nav mesh!
-			SetEntProp(iEntity, Prop_Send, "m_bDistributed", true);
+			
+			SDKHook(iEntity, SDKHook_SpawnPost, CritCash_OnSpawnPost);
 		}
 	}else if(g_iCreatingCartDispenser > 0 && strcmp(classname, "dispenser_touch_trigger") == 0)
 	{


### PR DESCRIPTION
Since, the 2015 Halloween update you fixed currency packs unspawning from maps with no nav.
However this caused crist cash dispatching red particles effect. But it used to be green.
As red cash particles in MvM means fake cash, or cash with no value, having red cash particles in STT is kinda weird, especially when it used to be green.

According to CCurrencyPack::Spawn function, the particle are selected when the entity spawns.

```
public int CCurrencyPack::Spawn()
{
    if (m_bDistributed)
    {
         DispatchParticleEffect("mvm_cash_embers_red", ATTACH_TYPE_SOMETHING, this);
    }
    else
    {
          DispatchParticleEffect("mvm_cash_embers", ATTACH_TYPE_SOMETHING, this);
    }     
}
```
The proper fix would be to wait the entity spawn and set the netprop after, I tried this a few times on maps with no navs, all my attempts were successful.
This pull request contains the proper fix.

Ps: I have an other fix that I would like to push, about tank parented to the cart. I know the current one is about changing the movetype of the tank, and prevent the console from displaying an error. I have an other one that doesn't involve blocking the think tick or changing the move type, if you are interested in it, let me know, I'll be making a pull request if you want me to.