### PR TITLE
Tank parenting improvement (WIP)

### DIFF
--- a/addons/sourcemod/gamedata/tank.txt
+++ b/addons/sourcemod/gamedata/tank.txt
@@ -316,6 +316,11 @@
 				"linux"		"19"
 				"windows"	"18"
 			}
+			"CBaseEntity::MyNextBotPointer"
+			{
+				"windows" 	"72"
+				"linux" 	"73"
+			}
 			"CBaseEntity::PhysicsSolidMaskForEntity"
 			{
 				"linux"		"168"
@@ -350,6 +355,21 @@
 			{
 				"linux"		"247"
 				"windows"	"241"
+			}
+			"INextBot::GetLocomotionInterface"
+			{
+				"linux"		"49"
+				"windows"	"48"
+			}
+			"ILocomotion::FaceTowards"
+			{
+				"linux"		"74"
+				"windows"	"73"
+			}
+			"NextBotGroundLocomotion::GetGravity"
+			{
+				"linux"		"106"
+				"windows"	"105"
 			}
 			"CAttributeManager::OnAttributeValuesChanged"
 			{


### PR DESCRIPTION
This is what I've been talking about in the last pull request #7, it still needs improvements, (especially on hightower event, where the tank "shakes" at the end), other than that it's pretty stable, and can be used safely.

The last thing to do, is to remove the parent playbackrate thing, and leave the Tank_Controller do everything, since the tank "can no longer go through objects".

I've added you on steam if you don't mind, it will be easier for you and me to communicate about those locomotion functions.