### PR TITLE
Jetpack crash fix

### DIFF
--- a/addons/sourcemod/scripting/tank_spawner.sp
+++ b/addons/sourcemod/scripting/tank_spawner.sp
@@ -545,6 +545,11 @@ public Action Spawner_Timer_Spawn(Handle hTimer, int client)
 					AcceptEntityInput(bomb, "ForceDrop");
 				}
 			}
+			
+			//Prevents a crash related to weapon switch animation
+			for (int iSlot = WeaponSlot_Primary; iSlot <= WeaponSlot_InvisWatch; iSlot++)
+				if (GetPlayerWeaponSlot(client, iSlot) > MaxClients)
+					TF2_RemoveItemInSlot(client, iSlot);
 
 			// Spawns a giant robot in the cached spawn position
 			float flPos[3];


### PR DESCRIPTION
This fixes the crash with the thermal thruster.
From my understanding this crash affects any gamemode that is force changing a player playing as pyro with jetpack equipped to sniper. Unfortunately STT is one of the gamemodes that may do that (jetpack pyro to giant sniper).