### PR TITLE
Fix Tank sometimes in buddha mode when shouldnt be

### DIFF
--- a/addons/sourcemod/scripting/tank.sp
+++ b/addons/sourcemod/scripting/tank.sp
@@ -8211,7 +8211,7 @@ public void OnEntityDestroyed(int entity)
 				StopSound(iTank, SNDCHAN_STATIC, "^mvm/mvm_tank_loop.wav");
 			}
 
-			if(GetEntPropEnt(iTank, Prop_Send, "moveparent") == entity)
+			if(GetEntPropEnt(iTank, Prop_Send, "moveparent") == entity && entity > 0)
 			{
 				// Give the tank godmode to prevent it from being destroyed by players at this point
 				SetEntProp(iTank, Prop_Data, "m_takedamage", DAMAGE_EVENTS_ONLY); // Buddah


### PR DESCRIPTION
`OnEntityDestroyed` can sometimes call `-1` as a entity, which is complete useless for us. However if tank don't have any entity as `moveparent`, value will also be `-1`. Meaning that both as `-1` can cause Tank to be in buddha mode when shouldn't really have happened.

Also it took us over a year to find and fix this bug, it quite of a story.